### PR TITLE
fixes build with clang

### DIFF
--- a/starstructor.pro
+++ b/starstructor.pro
@@ -1,5 +1,6 @@
 CONFIG += qt
 CONFIG += console
+CONFIG += c++11
 
 console {
 	DEFINES += ST_USE_CONSOLE
@@ -19,6 +20,7 @@ QMAKE_CXXFLAGS += -std=c++11
 ## Source files
 
 INCLUDEPATH += src/
+INCLUDEPATH += src/gui/
 
 HEADERS += src/stexception.hpp
 HEADERS += src/ststlspecialisation.hpp


### PR DESCRIPTION
This PR fixes build errors on OS X using clang.

BTW: I've created a [homebrew](http://brew.sh/) formula for this: https://gist.github.com/chrmoritz/9846074
(install it with `brew install https://gist.githubusercontent.com/chrmoritz/9846074/raw/starstructor.rb`)

atm Starstructor starts on OS X but doesn't render a proper gui: 
[screenshot](https://cloud.githubusercontent.com/assets/1686759/2556769/5a035f0a-b6de-11e3-93bd-a325e6bda952.png)
